### PR TITLE
Correctly find YourKey element inside XML document

### DIFF
--- a/KeysExportViewer/KeysCollection.cs
+++ b/KeysExportViewer/KeysCollection.cs
@@ -66,7 +66,7 @@ namespace KeysExportViewer
 
 			// Load the document
 			XDocument doc = XDocument.Load(filename);
-			var keyNodes = from productKey in doc.Element("YourKey").Elements("Product_Key")
+			var keyNodes = from productKey in doc.Descendants("YourKey").Elements("Product_Key")
 				let key = productKey.Element("Key")
 				where (int)int.Parse((string)key.Attribute("ID"), CultureInfo.InvariantCulture) != -3
 				select new


### PR DESCRIPTION
Latest **KeysExport.xml** format contains the `<YourKey>` element inside other elements.

This fixes the NullReferenceException when loading a new file format.

```
<root>
  <YourSubscription>
    <Subscription Name="Visual Studio Professional" />
  </YourSubscription>
  <YourKey>
    ...
  </YourKey>
</root>
```