### PR TITLE
Show all keys for a product name

### DIFF
--- a/KeysExportViewer/App.config
+++ b/KeysExportViewer/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/KeysExportViewer/KeysCollection.cs
+++ b/KeysExportViewer/KeysCollection.cs
@@ -16,7 +16,7 @@ namespace KeysExportViewer
 		/// <summary>
 		/// The keys
 		/// </summary>
-		private IDictionary<Guid, MsdnKey> keys = new Dictionary<Guid, MsdnKey>();
+		private IDictionary<string, MsdnKey> _keys = new Dictionary<string, MsdnKey>();
 		#endregion Data Members
 
 		#region Properties
@@ -24,7 +24,7 @@ namespace KeysExportViewer
 		/// Gets the keys.
 		/// </summary>
 		/// <value>The keys.</value>
-		public IReadOnlyDictionary<Guid, MsdnKey> Keys => new ReadOnlyDictionary<Guid, MsdnKey>(keys);
+		public IReadOnlyDictionary<string, MsdnKey> Keys => new ReadOnlyDictionary<string, MsdnKey>(_keys);
 		#endregion Properties
 
 		#region Constructors
@@ -52,7 +52,7 @@ namespace KeysExportViewer
 			}
 
 			// Get rid of the existing set of keys
-			keys = new Dictionary<Guid, MsdnKey>();
+			_keys.Clear();
 
 			// Load the document
 			var doc = XDocument.Load(filename);
@@ -88,8 +88,21 @@ namespace KeysExportViewer
 					}
 				}
 
-				keys.Add(Guid.NewGuid(), key);
-			}
+				// If the product already exists, add the new keys to it
+                if (_keys.TryGetValue(key.Name, out MsdnKey msdnKey))
+                {
+                    foreach (var individualKey in key.Keys)
+                    {
+						if(msdnKey.Keys.All(k => k.Key != individualKey.Key))
+                            msdnKey.AddKey(individualKey);
+                    }
+                }
+                else
+                {
+					// Add the new product and its keys
+                    _keys.Add(key.Name, key);
+                }
+            }
 		}
 		#endregion Private Methods
 	}

--- a/KeysExportViewer/KeysExportViewer.csproj
+++ b/KeysExportViewer/KeysExportViewer.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" />
   <Import Project="..\packages\Microsoft.NetFramework.Analyzers.3.3.0\build\Microsoft.NetFramework.Analyzers.props" Condition="Exists('..\packages\Microsoft.NetFramework.Analyzers.3.3.0\build\Microsoft.NetFramework.Analyzers.props')" />
   <Import Project="..\packages\Microsoft.NetCore.Analyzers.3.3.0\build\Microsoft.NetCore.Analyzers.props" Condition="Exists('..\packages\Microsoft.NetCore.Analyzers.3.3.0\build\Microsoft.NetCore.Analyzers.props')" />
@@ -14,7 +14,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>KeysExportViewer</RootNamespace>
     <AssemblyName>KeysExportViewer</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -33,6 +33,7 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -65,7 +66,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />


### PR DESCRIPTION
This project is exactly what I was looking for. Thanks a lot!

I thought it was maybe more useful to group the products by their name and show all the corresponding keys.
This way, the number of listed "products" becomes must shorter.

Before (_keys removed_):
![image](https://user-images.githubusercontent.com/10255664/211155324-22524f9f-4ea5-43ac-b6bc-c488c771a5a6.png)

With this PR (_keys removed_):
![image](https://user-images.githubusercontent.com/10255664/211155347-2bdeca95-b21b-4af1-b4b3-66e7fec4d6fb.png)

As soon as a product is selected, all keys will be copied to the clipboard, e.g.
```Text
Windows 10 Professional:

XXXXX-XXXXX-XXXXX-XXXXX-XXXXX (Retail)
XXXXX-XXXXX-XXXXX-XXXXX-XXXXX (Retail)
XXXXX-XXXXX-XXXXX-XXXXX-XXXXX (Retail)
```
So the keys don't have to be copied one by one.